### PR TITLE
Adds support for object spread

### DIFF
--- a/lib/parser/nodejs/exported_function_parser.js
+++ b/lib/parser/nodejs/exported_function_parser.js
@@ -58,7 +58,12 @@ class ExportedFunctionParser {
 
   parseModuleExportsStatement(fileString) {
 
-    let AST = babylon.parse(fileString);
+    let AST = babylon.parse(fileString, {
+      plugins: [
+        'objectRestSpread'
+      ]
+    });
+
     let body = AST.program.body;
 
     let statements = body.filter(item => {

--- a/tests/files/cases/function_valid_object_spread.js
+++ b/tests/files/cases/function_valid_object_spread.js
@@ -1,0 +1,18 @@
+/**
+* Valid function with an empty blacklist
+* @returns {object}
+*/
+module.exports = (callback) => {
+
+  let obj = {
+    akey: 'avalue'
+  }
+
+  let spreadObj = {
+    ...obj,
+    hey: 'o'
+  };
+  
+  return callback(null, spreadObj);
+
+};


### PR DESCRIPTION
Object spread has been available since node.js 8.3 but babylon require a plugin to parse it.